### PR TITLE
Implement `StreamConsumer`, not extend.

### DIFF
--- a/test/replay_stream_test.dart
+++ b/test/replay_stream_test.dart
@@ -2195,7 +2195,7 @@ class DelegatingMatcher extends CustomMatcher {
 
 /// A [StreamConsumer] that does not do anything. It does, however, provide a
 /// getter to the added [Stream] for test verification.
-class NoopStreamConsumer extends StreamConsumer<int> {
+class NoopStreamConsumer implements StreamConsumer<int> {
   Stream<int>? _stream;
 
   Stream<int>? get stream => _stream;


### PR DESCRIPTION
Changes one occurrence of `extends StreamConsumer` to `implements StreamConsumer`.

The class has no implementation to inherit, and will (hopefully) be made an `abstract interface class`.
Adding the `interface` was missed from the Dart 3.0 release, but this occurrence looks like the only potential blocker for adding it ASAP.